### PR TITLE
Fix Reaction suffix for OpenFOAM 7 only

### DIFF
--- a/Allconvert
+++ b/Allconvert
@@ -9,6 +9,10 @@ echo "Coverting multi step gri"
 python convert.py ./mechs/multiStep/cantera/ ./mechs/multiStep/output
 echo "Done convert multi step gri"
 echo
+echo "Converting multi step for OpenFOAM 7"
+python convert.py ./mechs/multiStep/cantera/ ./mechs/multiStep/of7 --version 7
+echo "Done convert multi step of7"
+echo
 
 echo "Coverting reverse"
 python convert.py ./mechs/reverse/cantera/ ./mechs/reverse/output


### PR DESCRIPTION
## Summary
- add `rtype_suffix` parameter to `writeReactions`, `reaction_block`, and `combined_reaction_block`
- apply the suffix only in the OpenFOAM 7 converter
- keep newer versions unchanged
- clean repo by removing generated OF7 outputs

## Testing
- `pip3 install cantera -q`
- `./Allconvert > /tmp/allconvert.log 2>&1 && tail -n 20 /tmp/allconvert.log`


------
https://chatgpt.com/codex/tasks/task_e_686bd92a9e9c832899dfaf73f1677d68